### PR TITLE
Make the error types public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ use rand_chacha::ChaChaRng;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 
-use errors::{DecryptionError, EncryptionError};
+pub use errors::{DecryptionError, EncryptionError};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EncryptedRecord {


### PR DESCRIPTION
So they can be referenced in code that uses enveloper, particularly
for constructing Result types.