### PR TITLE
Place the encrypted data key first in the EncryptedRecord

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,8 @@ pub use errors::{DecryptionError, EncryptionError};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EncryptedRecord {
-    pub ciphertext: Vec<u8>,
     pub encrypted_key: Vec<u8>,
+    pub ciphertext: Vec<u8>,
     pub nonce: [u8; 12],
     pub key_id: String,
 }


### PR DESCRIPTION
The intent of this change is to allow for "data key locality".
That is, if we sort a collection of serialised `EncryptedRecord`s, those which use the same data key will be adjacent.
The benefit of this is that when using a key store which has an expensive data key decryption operation, caching decrypted data keys will have a significant performance impact.