### PR TITLE
Fix Box<dyn KeyProvider> for envelope cipher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "envelopers"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envelopers"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"

--- a/src/key_provider.rs
+++ b/src/key_provider.rs
@@ -24,7 +24,7 @@ pub trait KeyProvider {
 }
 
 #[async_trait(?Send)]
-impl<K: KeyProvider> KeyProvider for Box<K> {
+impl KeyProvider for Box<dyn KeyProvider> {
     async fn generate_data_key(&self) -> Result<DataKey, KeyGenerationError> {
         (**self).generate_data_key().await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,6 @@
 //! # });
 //! ```
 
-
-
 mod errors;
 mod key_provider;
 
@@ -190,5 +188,36 @@ where
             encrypted_key: data_key.encrypted_key,
             key_id,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{EnvelopeCipher, SimpleKeyProvider, KeyProvider};
+
+    #[tokio::test]
+    async fn test_encrypt_decrypt() {
+        let provider: SimpleKeyProvider = SimpleKeyProvider::init([1; 16]);
+        let cipher: EnvelopeCipher<_> = EnvelopeCipher::init(provider);
+
+        let message = "hello".as_bytes();
+
+        let record = cipher.encrypt(message).await.unwrap();
+        let decrypted = cipher.decrypt(&record).await.unwrap();
+
+        assert_eq!(String::from_utf8(decrypted).unwrap(), "hello");
+    }
+
+    #[tokio::test]
+    async fn test_encrypt_decrypt_boxed() {
+        let provider: SimpleKeyProvider = SimpleKeyProvider::init([1; 16]);
+        let cipher: EnvelopeCipher<Box<dyn KeyProvider>> = EnvelopeCipher::init(Box::new(provider));
+
+        let message = "hello".as_bytes();
+
+        let record = cipher.encrypt(message).await.unwrap();
+        let decrypted = cipher.decrypt(&record).await.unwrap();
+
+        assert_eq!(String::from_utf8(decrypted).unwrap(), "hello");
     }
 }


### PR DESCRIPTION
For some reason the other version didn't work with `EnvelopeCipher`. This fixes that + adds tests.
