### PR TITLE
Temporarily change name back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "envelopers"
+name = "enveloper"
 version = "0.1.2"
 dependencies = [
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "envelopers"
+name = "enveloper"
 version = "0.1.2"
 edition = "2021"
 license = "GPL-3.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Envelopers
+# Enveloper
 
 Very simple envelope encryption library in Rust using [aes-gcm](https://crates.io/crates/aes-gcm) and a `KeyProvider`
 trait. KeyProviders can be implemented for AWS KMS, Azure KeyVault, Hashicorp Vault etc but this library just comes with

--- a/examples/kms.rs
+++ b/examples/kms.rs
@@ -1,5 +1,5 @@
 use aws_sdk_kms::Client;
-use envelopers::{EnvelopeCipher, KMSKeyProvider};
+use enveloper::{EnvelopeCipher, KMSKeyProvider};
 use std::error::Error;
 
 #[tokio::main]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! The `SimpleKeyProvider` allows envelope encryption to be used with a local key.
 //!
 //! ```rust
-//! use envelopers::{EnvelopeCipher, SimpleKeyProvider};
+//! use enveloper::{EnvelopeCipher, SimpleKeyProvider};
 //!
 //! # use tokio::runtime::Runtime;
 //! # let rt = Runtime::new().unwrap();
@@ -32,7 +32,7 @@
 //! ## Encoding a CipherText
 //!
 //! ```rust
-//! # use envelopers::{EnvelopeCipher, SimpleKeyProvider};
+//! # use enveloper::{EnvelopeCipher, SimpleKeyProvider};
 //! #
 //! # use tokio::runtime::Runtime;
 //! # let rt = Runtime::new().unwrap();
@@ -52,7 +52,7 @@
 //!
 //! ## Decrypting a CipherText
 //! ```rust
-//! use envelopers::{EnvelopeCipher, SimpleKeyProvider, EncryptedRecord};
+//! use enveloper::{EnvelopeCipher, SimpleKeyProvider, EncryptedRecord};
 //!
 //! #
 //! # use tokio::runtime::Runtime;


### PR DESCRIPTION
This is breaking enveloperb because it uses the dep from git. Temporarily change the name back to fix the issue for now.