### PR TITLE
Make Key<U16>, errors, DataKey public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enveloper"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,26 +76,29 @@
 //! # });
 //! ```
 
-mod errors;
+pub mod errors;
 mod key_provider;
 
 mod kms_key_provider;
 mod simple_key_provider;
 
-pub use crate::key_provider::KeyProvider;
+pub use crate::key_provider::{DataKey, KeyProvider};
 
 pub use crate::kms_key_provider::KMSKeyProvider;
 pub use crate::simple_key_provider::SimpleKeyProvider;
 
+pub use aes_gcm::aes::cipher::consts::U16;
+pub use aes_gcm::Key;
+
 use aes_gcm::aead::{Aead, NewAead, Payload};
-use aes_gcm::{Aes128Gcm, Key, Nonce};
+use aes_gcm::{Aes128Gcm, Nonce};
 // Or `Aes256Gcm`
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 
-pub use errors::{DecryptionError, EncryptionError};
+pub use errors::{DecryptionError, EncryptionError, KeyDecryptionError, KeyGenerationError};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EncryptedRecord {


### PR DESCRIPTION
In order to create a custom key provider, these things need to be public.
