### PR TITLE
Bump envelopers to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enveloper"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"


### PR DESCRIPTION
Bumps the version to 0.2.0. Will publish after merging.
