### PR TITLE
fix(ci): bump deprecated GitHub Actions to unblock workflow runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
     name: "🧪 Test"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -31,10 +31,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install minimal nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: "Test"
         run: |
@@ -49,9 +46,9 @@ jobs:
     name: "⏱ Benchmark"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -62,10 +59,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install minimal nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: "Benchmark"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Install minimal nightly
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # nightly
+        with:
+          toolchain: nightly
 
       - name: "Test"
         run: |
@@ -60,6 +62,8 @@ jobs:
 
       - name: Install minimal nightly
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # nightly
+        with:
+          toolchain: nightly
 
       - name: "Benchmark"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install minimal nightly
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # nightly
 
       - name: "Test"
         run: |
@@ -59,7 +59,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install minimal nightly
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # nightly
 
       - name: "Benchmark"
         run: |


### PR DESCRIPTION
## Summary

GitHub Actions was recently enabled for this repo. The first manual run of the "Test" workflow ([run 31995995184](https://github.com/cipherstash/envelopers/actions/runs/31995995184)) failed immediately at the **"Set up job"** step on both jobs ("🧪 Test" and "⏱ Benchmark"), before any real steps executed:

```
##[error]This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions.
```

This is a hard, GitHub-side auto-fail applied to any workflow referencing `actions/cache@v1`/`@v2`. It blocks CI entirely regardless of what the workflow actually does.

This PR is a minimal, mechanical action-version bump in `.github/workflows/test.yml` to unblock CI — it does not change any workflow logic, triggers, cargo commands, or cache keys.

- `actions/cache@v2` → `actions/cache@v4` (both jobs) — fixes the auto-fail described above.
- `actions/checkout@v2` → `actions/checkout@v4` (both jobs) — same class of deprecation, bumped while touching this file.
- `actions-rs/toolchain@v1` → `dtolnay/rust-toolchain@nightly` (both jobs) — the `actions-rs` org is archived/unmaintained, and this action is a known source of CI breakage (it fetches a stale rustup index). Replaced with the actively-maintained `dtolnay/rust-toolchain` action; the `@nightly` tag itself selects the nightly toolchain, and minimal profile is its default, so no `with:` block is needed.

## Why not fix the dependency/security issues here

This PR only addresses CI infrastructure (deprecated Actions causing auto-fails). It is unrelated to the dependency version bumps handled in PR #57 / the security-remediation work.

Ref: [CIP-3794](https://linear.app/cipherstash/issue/CIP-3794/fix-ci-deprecated-actionscache-v2-auto-fails-all-workflow-runs)

## Test plan

- [x] Triggered the `test.yml` workflow via `workflow_dispatch` on this branch and confirmed it gets past "Set up job" (no more auto-fail).
- [ ] Reviewer to confirm workflow run results look reasonable.