### PR TITLE
fix(ci): pin Rust toolchain to stable 1.97.1 instead of nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,8 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install minimal nightly
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # nightly
-        with:
-          toolchain: nightly
+      - name: Install Rust 1.97.1
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: "Test"
         run: |
@@ -60,10 +58,8 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install minimal nightly
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # nightly
-        with:
-          toolchain: nightly
+      - name: Install Rust 1.97.1
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: "Benchmark"
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #58. That PR fixed the deprecated-action auto-fail blocking all CI runs, but kept the workflow on the `nightly` Rust channel, which has been in place unexamined since the workflow was first added in 2022.

Nightly is a floating, unreproducible build target. Nothing in this crate actually requires it:

- `cargo test` — passes cleanly on stable
- `cargo check --no-default-features` — passes cleanly on stable
- `cargo bench` — passes cleanly on stable (no `#[bench]`/libtest harness usage in this crate; the `bench` job doesn't need nightly)

This bumps both jobs (`test`, `bench`) to `dtolnay/rust-toolchain@1.97.1`, which pins the exact stable Rust release rather than floating on `nightly`.

Ref: CIP-3794.

## Test plan

- [x] CI test suite (this PR's own run)
- [x] CI no-default-features check
- [x] CI benchmark job